### PR TITLE
Update Docker base image and run image build on schedule

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  schedule:
+    - cron: '0 2 1 * *'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [ master ]
   schedule:
+    # Run once per month on the 1st day at 02:00 UTC.
     - cron: '0 2 1 * *'
   workflow_dispatch:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3-bullseye
+FROM python:3.12-bookworm
 
-ARG PLATFORM_IO_VERSION=6.1.1
+ARG PLATFORM_IO_VERSION=6.1.19
 
 # Update PIP
 RUN pip install --upgrade pip


### PR DESCRIPTION
- Switch the image to Python 3.12 on Debian Bookworm and update the default PlatformIO version to 6.1.19
- Add a monthly scheduled workflow run so the image is rebuilt regularly.

Closes #17
Closes #18